### PR TITLE
Fix job date processing after change in LSF date format

### DIFF
--- a/lsf/readjobs.py
+++ b/lsf/readjobs.py
@@ -85,13 +85,11 @@ def readjobs(args, fast=False):
             elif key in ("submit_time", "start_time", "finish_time"):
                 if val[-1] in "ELXA":
                     val = val[:-2]
-                year = strftime("%Y")
-                job[key] = mktime(strptime(year + " " + val,
-                                           "%Y %b %d %H:%M"))
+                job[key] = mktime(strptime(val,
+                                           "%b %d %H:%M:%S %Y"))
                 if key != "finish_time" and job[key] > time():
-                    year = str(int(year) - 1)
-                    job[key] = mktime(strptime(year + " " + val,
-                                               "%Y %b %d %H:%M"))
+                    job[key] = mktime(strptime(val,
+                                               "%b %d %H:%M:%S %Y"))
             elif key == "time_left":
                 if val[-1] in "ELXA":
                     val = val[:-2]

--- a/lsf/readjobs.py
+++ b/lsf/readjobs.py
@@ -87,9 +87,6 @@ def readjobs(args, fast=False):
                     val = val[:-2]
                 job[key] = mktime(strptime(val,
                                            "%b %d %H:%M:%S %Y"))
-                if key != "finish_time" and job[key] > time():
-                    job[key] = mktime(strptime(val,
-                                               "%b %d %H:%M:%S %Y"))
             elif key == "time_left":
                 if val[-1] in "ELXA":
                     val = val[:-2]


### PR DESCRIPTION
Job descriptors include now a full date with seconds and current year. The old version would throw an exception due to incorrect time format passed to `strptime`. An example of stack trace:

```
Traceback (most recent call last):
  File "/home/mc306023/python-lsf/lsf/ehosts.py", line 155, in <module>
    main()
  File "/home/mc306023/python-lsf/lsf/ehosts.py", line 149, in main
    ehosts(args, bhostsargs)
  File "/home/mc306023/python-lsf/lsf/ehosts.py", line 55, in ehosts
    jobs = readjobs(["-u", "all", "-r", "-m", " ".join(hostnames)])
  File "/rwthfs/rz/cluster/home/mc306023/python-lsf/lsf/readjobs.py", line 92, in readjobs
    "%b %d %H:%M:%S %Y"))
  File "/usr/lib64/python2.7/_strptime.py", line 467, in _strptime_time
    return _strptime(data_string, format)[0]
  File "/usr/lib64/python2.7/_strptime.py", line 325, in _strptime
    (data_string, format))
ValueError: time data '2018 Apr  9 20:32:55 2018' does not match format '%b %d %H:%M:%S %Y'
```